### PR TITLE
Script improvements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_security_group_rule" "local-ssh" {
   type              = "ingress"
   to_port           = 22
   protocol          = "tcp"
-  cidr_blocks       = ["${chomp(data.http.myip.body)}/32"]
+  cidr_blocks       = ["${chomp(data.http.myip.response_body)}/32"]
   from_port         = 22
   security_group_id = aws_security_group.sg.id
 }
@@ -71,7 +71,7 @@ resource "aws_security_group_rule" "local-prompgexp" {
   type              = "ingress"
   to_port           = 9187
   protocol          = "tcp"
-  cidr_blocks       = ["${chomp(data.http.myip.body)}/32"]
+  cidr_blocks       = ["${chomp(data.http.myip.response_body)}/32"]
   from_port         = 9187
   security_group_id = aws_security_group.sg.id
 }

--- a/scripts/configServers.sh
+++ b/scripts/configServers.sh
@@ -12,27 +12,29 @@ fi
 source $clDir/env.sh
 d1=driver1-1
 
-key="keys/dl-m1book-key.pem"
+key="keys/${KEY_NAME:-dl-m1book-key.pem}"
 usr=centos
 SSH="ssh -i $key -o StrictHostKeyChecking=no"
 SCP="scp -i $key -o StrictHostKeyChecking=no"
 PASS=$(openssl rand -hex 8;)
 
+echo "using key: $key"
+
 $SCP $clDir/ansible_hosts  $usr@$d1:.
 $SCP ansible/add-key.yml $usr@$d1:.
 
 ## Cat hosts to /etc/hosts on each VM
-ansible-playbook -i $clDir/ansible_hosts --user centos --key-file keys/dl-m1book-key.pem ansible/cat-hosts.yml
+ansible-playbook -i $clDir/ansible_hosts --user centos --key-file $key ansible/cat-hosts.yml
 
 $SSH $usr@$d1 'mkdir keys'
 $SCP $key $usr@$d1:keys/.
 $SSH $usr@$d1 'echo -e "\n\n\n" | ssh-keygen -t rsa'
 
 ## Add keys to each VM
-$SSH $usr@$d1 'ansible-playbook -i ansible_hosts --user centos --key-file keys/dl-m1book-key.pem  -e "key=/home/centos/.ssh/id_rsa.pub" add-key.yml'
+$SSH $usr@$d1 "ansible-playbook -i ansible_hosts --user centos --key-file $key -e \"key=/home/centos/.ssh/id_rsa.pub\" add-key.yml"
 
 ## Run io install and build bmsql, set up password file
-ansible-playbook -i $clDir/ansible_hosts_driver --user centos --key-file keys/dl-m1book-key.pem -e "PGV=$PGV" ansible/io-install.yml
+ansible-playbook -i $clDir/ansible_hosts_driver --user centos --key-file $key -e "PGV=$PGV" ansible/io-install.yml
 pw='echo '
 pw+=$PASS
 pw+=' >> test/tf-nimoy/remote/.pword'

--- a/scripts/gen_tf_vars.py
+++ b/scripts/gen_tf_vars.py
@@ -11,7 +11,6 @@ if len(sys.argv) < 3 or len(sys.argv) > 4:
   print("ERROR: Two or three parms must be specified: provider location [zone]")
   sys.exit(1)
 
-
 ############### MAINLINE ######################
 provider = sys.argv[1]
 loct = sys.argv[2]
@@ -21,6 +20,7 @@ if len(sys.argv) == 4:
 
 opsys = os.getenv("OPSYS", "")
 plat = os.getenv("PLATFORM", "")
+key_name = os.getenv("KEY_NAME", "dl-m1book-key").removesuffix(".pem")
 
 if ((opsys == "") or (plat == "")):
   print("ERROR: The OPSYS & PLATFORM environment variables both need to be set")
@@ -62,5 +62,5 @@ if region != parent_region:
 
 print('variable "az"          { default = "' + az + '" }')
 print('variable "image"       { default = "' + image_id + '" }')
-print('variable "key"         { default = "dl-m1book-key" }')
+print('variable "key"         { default = "' + key_name + '" }')
 


### PR DESCRIPTION
1. Update HCL to use `data.http.myip.response_body` since `body` is deprecated
2. Support overriding EC2 keypair name using a `KEY_NAME` env var

If `KEY_NAME` is not set in your environment, it will still default to `dl-m1book-key.pem` so everyone's existing setups will still work.